### PR TITLE
fix：修复角色分配用户时会有重复用户ID的情况。

### DIFF
--- a/maku-boot-system/src/main/java/net/maku/system/dao/SysUserRoleDao.java
+++ b/maku-boot-system/src/main/java/net/maku/system/dao/SysUserRoleDao.java
@@ -23,4 +23,12 @@ public interface SysUserRoleDao extends BaseDao<SysUserRoleEntity> {
      * @return  返回角色ID列表
      */
     List<Long> getRoleIdList(@Param("userId") Long userId);
+
+    /**
+     * 根据角色ID查询对应的用户ID列表
+     * @param roleId  角色ID
+     *
+     * @return  返回用户ID列表
+     */
+    List<Long> getExistsUserIdList(@Param("roleId") Long roleId);
 }

--- a/maku-boot-system/src/main/java/net/maku/system/service/SysUserRoleService.java
+++ b/maku-boot-system/src/main/java/net/maku/system/service/SysUserRoleService.java
@@ -51,4 +51,10 @@ public interface SysUserRoleService extends BaseService<SysUserRoleEntity> {
      * @param userId  用户ID
      */
     List<Long> getRoleIdList(Long userId);
+
+    /**
+     * 根据角色ID查询对应的用户ID列表
+     * @param roleId  角色ID
+     */
+    List<Long> getExistsUserIdList(Long roleId);
 }

--- a/maku-boot-system/src/main/java/net/maku/system/service/impl/SysUserRoleServiceImpl.java
+++ b/maku-boot-system/src/main/java/net/maku/system/service/impl/SysUserRoleServiceImpl.java
@@ -91,4 +91,9 @@ public class SysUserRoleServiceImpl extends BaseServiceImpl<SysUserRoleDao, SysU
     public List<Long> getRoleIdList(Long userId) {
         return baseMapper.getRoleIdList(userId);
     }
+
+    @Override
+    public List<Long> getExistsUserIdList(Long roleId) {
+        return baseMapper.getExistsUserIdList(roleId);
+    }
 }

--- a/maku-boot-system/src/main/resources/mapper/SysUserRoleDao.xml
+++ b/maku-boot-system/src/main/resources/mapper/SysUserRoleDao.xml
@@ -7,4 +7,7 @@
         select role_id from sys_user_role where user_id = #{userId} and deleted = 0
     </select>
 
+    <select id="getExistsUserIdList" resultType="long">
+        select user_id from sys_user_role where role_id = #{roleId} and deleted = 0
+    </select>
 </mapper>


### PR DESCRIPTION
角色管理模块，在给指定角色分配用户时存在可重复新增用户并插入数据库成功的问题。这个PR在代码层先检查该角色已有用户列表，过滤掉已存在的用户ID，然后再插入到数据库。